### PR TITLE
Bump LaunchBar version to 5.6.1

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -3,6 +3,6 @@ class launchbar {
   package { 'Launchbar':
     ensure   => installed,
     provider => 'appdmg_eula',
-    source   => 'http://www.obdev.at/downloads/launchbar/LaunchBar-5.6.1.dmg',
+    source   => 'http://www.obdev.at/downloads/launchbar/LaunchBar-5.6.2.dmg',
   }
 }


### PR DESCRIPTION
Bumps LaunchBar version to 5.6.1 (Mavericks-compatible)
